### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/create-release-on-tag.yml
+++ b/.github/workflows/create-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
 
       - name: Extract project version from Maven

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Display Maven version
         run: ./mvnw -v
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: OWASP Dependency Check
         run: ./mvnw -ntp org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=7.0 -DnvdApiKeyEnvironmentVariable=NVD_API_KEY

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<docker.image>fakesmtp</docker.image>
 
         <error-prone.version>2.42.0</error-prone.version>


### PR DESCRIPTION
Resolves #30.

Upgrades the build from Java 17 to Java 21 (via OpenRewrite `UpgradeBuildToJava21`):
- `pom.xml` `java.version` 17 → 21
- JDK 17 → 21 in the GitHub Actions workflows

Verified locally: `mvn verify` is green under Temurin 21 — all 13 previously-passing tests still pass (no test lost).

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
